### PR TITLE
Detect issue links that come after newlines

### DIFF
--- a/src/githubProcessing/handleGitHub.js
+++ b/src/githubProcessing/handleGitHub.js
@@ -40,7 +40,7 @@ function processRepo(repos){
 
   for(var componentIndex = 0; componentIndex < components.length; componentIndex++){
     var commentBody = $(components[componentIndex]);
-    var splittedBody = commentBody.text().toString().split(" ");
+    var splittedBody = commentBody.text().toString().split(/\s/);
     for( var i in splittedBody){
       var text = splittedBody[i];
       for(var j in repos){


### PR DESCRIPTION
The previous code split only on spaces, so if an issue link was the first thing on a line it wouldn't be detected.