### PR TITLE
Add require.js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,6 +6,7 @@
     "jquery": "2.2.3",
     "react-bootstrap": "~0.28.5",
     "bootstrap": "~3.3.6",
-    "opentip": "~2.4.6"
+    "opentip": "~2.4.6",
+    "requirejs": "~2.3.5"
   }
 }


### PR DESCRIPTION
When using the repo from source to add a new feature, I got the error that react.js was missing in the vendor directory.

I am no JavaScript/browser extension expert, but I think it should go in the bower.json file