### PR TITLE
Split on punctuation

### DIFF
--- a/src/githubProcessing/handleGitHub.js
+++ b/src/githubProcessing/handleGitHub.js
@@ -46,10 +46,6 @@ function processRepo(repos){
       for(var j in repos){
         var repo = repos[j];
         if (splittedBody[i].indexOf(repo.keyword) > -1){
-          if(text.indexOf(repo.targetURL) > -1){
-            //ignore this part since it already contains a proper link
-            continue;
-          }
           //Clean the link from some symbols usually added to destinguish issue-id from commit message
           var issueId = text.replaceAll("[", "").replaceAll("\\]", "").replaceAll(")", "").replaceAll("(", "").replaceAll("#", "").trim();
           var newId = pageRelativeIssueId++;

--- a/src/githubProcessing/handleGitHub.js
+++ b/src/githubProcessing/handleGitHub.js
@@ -40,7 +40,7 @@ function processRepo(repos){
 
   for(var componentIndex = 0; componentIndex < components.length; componentIndex++){
     var commentBody = $(components[componentIndex]);
-    var splittedBody = commentBody.text().toString().split(/[\s.,;]/);
+    var splittedBody = commentBody.text().toString().split(/[\s\.,;]/);
     for( var i in splittedBody){
       var text = splittedBody[i];
       for(var j in repos){

--- a/src/githubProcessing/handleGitHub.js
+++ b/src/githubProcessing/handleGitHub.js
@@ -40,7 +40,7 @@ function processRepo(repos){
 
   for(var componentIndex = 0; componentIndex < components.length; componentIndex++){
     var commentBody = $(components[componentIndex]);
-    var splittedBody = commentBody.text().toString().split(/\s/);
+    var splittedBody = commentBody.text().toString().split(/[\s.,;]/);
     for( var i in splittedBody){
       var text = splittedBody[i];
       for(var j in repos){


### PR DESCRIPTION
The fix on whitespace #1 is nice, but often we have references that are at the end of the line like:
```
This PR fixes the first part of ISSUE-1.
```

or in a list:
```
Part of ISSUE-1, ISSUE-2, and ISSUE-3
```

(These are just simple examples, but the idea is clear I suppose)

This PR adds `.`, `,` and `;` to the 'split list', making sure that these situations are properly working

Note that this problems can be solved better using the 'keys' of the repo management/configuration, and some dynamic regex (depending on those keys). As I did not write this extension, it would take me too much time (my boss wouldn't like it :wink: ) to rewrite the `processRepo()` function